### PR TITLE
Eliminate a delegate call in `ThreadPoolTypedWorkItemQueue` et. al.

### DIFF
--- a/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.IO.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/PortableThreadPool.IO.Windows.cs
@@ -5,7 +5,6 @@ using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Internal.Runtime.CompilerServices;
 
 namespace System.Threading
 {
@@ -116,7 +115,7 @@ namespace System.Threading
 
                 _nativeEvents =
                     (Interop.Kernel32.OVERLAPPED_ENTRY*)
-                    NativeMemory.Alloc((nuint)NativeEventCapacity * (nuint)Unsafe.SizeOf<Interop.Kernel32.OVERLAPPED_ENTRY>());
+                    NativeMemory.Alloc(NativeEventCapacity, (nuint)sizeof(Interop.Kernel32.OVERLAPPED_ENTRY));
                 _events = new(default);
 
                 // Thread pool threads must start in the default execution context without transferring the context, so


### PR DESCRIPTION
I opened this PR to add to the corresponding `dotnet/runtime` PR, because GitHub's review suggestions do not allow such big suggestions.

The `ThreadPoolTypedWorkItemQueue<T>` class invokes a callback for every work item, which it gets from a delegate on its constructor. In this PR I eliminated this delegate by adding a second callback type parameter to the class, which will be optimized by the JIT to call it directly, reducing indirections.

I also figured out another way to allocate the events buffer, by using the language's `sizeof` operator. [It does not reduce performance.](https://sharplab.io/#v2:EYLgxg9gTgpgtADwGwBYA0AXEBDAzgWwB8ABAJgEYBYAKGIAYACY8gOgBUALWbAEwEsAdgHMA3DXpNWAJQCuAjH3wwWASXkwoEAA4BlDQDc+YGLjG1GzFrPmLlAYQj4tfADYa9UQ8dM0aAbR0MKBkwDAAZbABPCBkMAAoI6NiAaUEeFj0ARxkYG2wXAEoAXRpBDA0BfIY5XGwAMxgGXCCQjAYAeQA1AFEpMIBBAAVB7oARAH1ugDk2KQBNGgBvGgZVpgBmBgBVNQxBoIYXLQcnNwUIAWSYSLM1jYYp7AV9GHaXqBdsLS0YHgAqQ5aN4aT7fX63NbETY7eT7KAMXYVfIQ1ZQ6plBg8ADuUxk+GAGnadQAQpFyrg2FBsAJcA0oLAeCjJEgmCgAf0XC4IGAALJxAoMAC8AD4Hk8+C8eTB8NBIiwOVywHFyHRSOgGHEBDIygUedgoLgOPkMnwAF6vOoAHi6vQGwzGkxm82F/IKTOYLOIbIYCu5W35QtFj2eMClMqgct9SpVarQGq1Oq2NPqyh0Zot1p6fSGIwm01mcxdBTdK0h5E93qjAZFYpDYdl8s53OVqvVmu18gKuHTEDqcRt2fteadc2LZgAvjQgA==)